### PR TITLE
feat: create Team entity class in model package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>6.2.13.Final</version>
+        </dependency>
 
         <!-- dependencies -->
     </dependencies>

--- a/src/main/java/mydigitalprofile/model/Team.java
+++ b/src/main/java/mydigitalprofile/model/Team.java
@@ -1,0 +1,89 @@
+package mydigitalprofile.model;
+
+import javax.persistence.*;
+
+/**
+ * Represents a Team entity in the application.
+ * Each team has a unique ID, a project ID, a team leader, and a project.
+ *
+ * @author Khaled Alnahhas
+ */
+@Entity
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teamID;
+
+    @Column
+    private Long projektID;
+
+    @ManyToOne
+    @JoinColumn(name = "teamleiter_id")
+    private TeamLeiter teamleiter;
+
+    @ManyToOne
+    @JoinColumn(name = "projekt_id")
+    private Projekt projekt;
+
+    // Getters and setters
+
+    public Long getTeamID() {
+        return teamID;
+    }
+
+    public void setTeamID(Long teamID) {
+        this.teamID = teamID;
+    }
+
+    public Long getProjektID() {
+        return projektID;
+    }
+
+    public void setProjektID(Long projektID) {
+        this.projektID = projektID;
+    }
+
+    public TeamLeiter getTeamleiter() {
+        return teamleiter;
+    }
+
+    public void setTeamleiter(TeamLeiter teamleiter) {
+        this.teamleiter = teamleiter;
+    }
+
+    public Projekt getProjekt() {
+        return projekt;
+    }
+
+    public void setProjekt(Projekt projekt) {
+        this.projekt = projekt;
+    }
+
+    // equals(), hashCode(), toString()
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Team team = (Team) o;
+
+        return teamID != null ? teamID.equals(team.teamID) : team.teamID == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return teamID != null ? teamID.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Team{" +
+                "teamID=" + teamID +
+                ", projektID=" + projektID +
+                ", teamleiter=" + teamleiter +
+                ", projekt=" + projekt +
+                '}';
+    }
+}


### PR DESCRIPTION
This pull request introduces the `Team` entity class in the `model` package. The `Team` class represents a team in our application and is mapped to the `Team` table in our database. Each team has a unique ID, a project ID, a team leader, and a project. The relationships between `Team` and `TeamLeiter`, and `Team` and `Projekt` are represented using JPA annotations. This class also includes getters and setters for all fields, and overrides `equals()`, `hashCode()`, and `toString()` methods.