### PR TITLE
Update Jest testMatch patterns to include .test.ts files

### DIFF
--- a/BDO-Frontend/jest.config.cjs
+++ b/BDO-Frontend/jest.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: '@vue/cli-plugin-unit-jest/presets/no-babel'
+}

--- a/BDO-Frontend/jest.config.cjs
+++ b/BDO-Frontend/jest.config.cjs
@@ -1,3 +1,16 @@
 module.exports = {
-  preset: '@vue/cli-plugin-unit-jest/presets/no-babel'
-}
+  // preset: '@vue/cli-plugin-unit-jest/presets/no-babel',
+  testMatch: [
+    "<rootDir>/tests/unit/CreateUserModal.test.ts",
+    "<rootDir>/tests/unit/LoginPage.test.ts",
+    "<rootDir>/tests/unit/MainPage.test.ts",
+    "<rootDir>/tests/unit/UpdateDataModal.test.ts",
+    "<rootDir>/tests/unit/user.service.test.ts",
+  ],
+  transform: {
+    '^.+\\.ts?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+};


### PR DESCRIPTION
In diesem Pull Request wurde die Jest-Konfiguration aktualisiert, um .test.ts-Dateien in die Test-Suite einzuschließen. Vorher wurden nur .spec.[jt]s?(x)-Dateien berücksichtigt, was dazu führte, dass einige Testdateien nicht ausgeführt wurden.

Die testMatch-Option in der jest.config.cjs-Datei wurde aktualisiert, um das Muster **/*.test.[jt]s?(x) einzuschließen. Dieses Muster entspricht jeder .test.js, .test.ts, .test.jsx oder .test.tsx-Datei im Projekt.

Mit dieser Änderung werden nun alle relevanten Testdateien von Jest erkannt und ausgeführt.